### PR TITLE
Allow VMs management in node role

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,4 +70,6 @@ The repository [ansible-avalanche-getting-started](https://github.com/Nuttymoon/
 
 - [x] Avalanche transaction module
 - [x] Subnet role
+- [x] VMs management
 - [ ] Blockchain role
+- [ ] TLS support

--- a/roles/node/README.md
+++ b/roles/node/README.md
@@ -3,6 +3,7 @@
 This Ansible role allows to bootstrap Avalanche nodes:
 
 - Install and configure [AvalancheGo](https://github.com/ava-labs/avalanchego) following Linux best practices
+- Install Virtual Machines that can later be used to create blockchains
 - (On local networks) Create an account with access to pre-funded addresses as described [here](https://docs.avax.network/build/tutorials/platform/fund-a-local-test-network)
 
 ## Role variables
@@ -18,6 +19,7 @@ This Ansible role allows to bootstrap Avalanche nodes:
 | `avalanchego_conf_dir`            | Where to store AvalancheGo config files                                                                                                                                             | `/etc/avalanche/avalanchego/conf`                              |
 | `avalanchego_certs_dir`           | Where to store the node's TLS certs                                                                                                                                                 | `/etc/avalanche/avalanchego/staking`                           |
 | `avalanchego_log_dir`             | Where to write logs                                                                                                                                                                 | `/var/log/avalanche/avalanchego`                               |
+| `avalanchego_vms_dir`             | Where to unpack VMs logs                                                                                                                                                            | `/opt/avalanche/vms`                                           |
 | `avalanchego_user`                | The user that will run the AvalancheGo Linux service                                                                                                                                | `avalanche`                                                    |
 | `avalanchego_use_static_ip`       | Wether to explicitly set the node's [public IP](https://docs.avax.network/build/references/avalanchego-config-flags#public-ip). If `yes` will use the IP provided in the inventory. | `yes`                                                          |
 | `avalanchego_http_host`           | [--http-host](https://docs.avax.network/build/references/avalanchego-config-flags#--http-host-string) argument                                                                      | `127.0.0.1`                                                    |
@@ -34,11 +36,7 @@ This Ansible role allows to bootstrap Avalanche nodes:
 | `avalanche_prefunded_password`    | The password for `avalanche_prefunded_username`                                                                                                                                     | `I_l1ve_@_Endor`                                               |
 | `avalanche_prefunded_private_key` | The private key used to access pre-funded addresses                                                                                                                                 | `PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN` |
 | `avalanche_whitelisted_subnets`   | [--whitelisted-subnets-string](https://docs.avax.network/build/references/avalanchego-config-flags/#--whitelisted-subnets-string) argument                                          | `""`                                                           |
-| `avalanche_vm_aliases`            | Object containing a list of aliases for each VM ID. See [VM Configs](https://docs.avax.network/build/references/avalanchego-config-flags/#vm-configs)                               | `tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH:`           |
-|                                   |                                                                                                                                                                                     | ` - timestampvm`                                               |
-|                                   |                                                                                                                                                                                     | ` - timestamp`                                                 |
-|                                   |                                                                                                                                                                                     | `spePNvBxaWSYL2tB5e2xMmMNBQkXMN8z2XEbz1ML2Aahatwoc:`           |
-|                                   |                                                                                                                                                                                     | ` - subnetevm`                                                 |
+| `avalanchego_vms_install`         | The list of VMs to install on the node with their versions. VM names and versions are separated by `=`. See [VMs install](#vms-installation).                                       | `['timestampvm=1.2.0']`                                        |
 
 **Note:** All config arguments are passed to AvalancheGo through a JSON config file stored at `avalanchego_config_dir`
 
@@ -61,6 +59,31 @@ The default installation follows [Linux Filesystem Hierarchy Standard](https://r
   - `/var/lib/avalanchego/db` contains AvalancheGo's database
 
 **Note:** This differs from AvalancheGo default setup that stores the database and configuration files under `$HOME/.avalanchego`.
+
+## VMs installation
+
+To install a VM on the node, add it to `avalanchego_vms_install` following `VM_NAME=VM_VERSION` format (e.g. `timestampvm=1.2.0`).
+
+**Note:** If `avalanchego_vms_install` is specified in your inventory, you have to list **all the VMs** to be installed (there isn't any merge with the default list).
+
+### Available VMs and AvalancheGo compatibility
+
+List of VMs currently available for install:
+
+- The [Timestamp Virtual Machine](https://github.com/ava-labs/timestampvm): versions `1.2.0` and later
+- The [Subnet EVM](https://github.com/ava-labs/subnet-evm): all versions
+- The [Spaces Virtual Machine](https://github.com/ava-labs/spacesvm): all versions
+
+Here is the compatibility matrix with AvalancheGo versions:
+
+| AvalancheGo     | `timestampvm` | `subnetevm` | `spacesvm` |
+| --------------- | ------------- | ----------- | ---------- |
+| `1.7.[0,1,2,3]` | `1.2.0`       | `0.1.0`     | `0.0.1`    |
+| `1.7.4`         | `1.2.[0,1]`   | `0.1.0`     | `0.0.1`    |
+| `1.7.[5,6]`     | `1.2.2`       | `0.1.[1,2]` | `0.0.2`    |
+| `1.7.7`         | -             | `0.2.0`     | -          |
+
+**Note:** If an versions incompatibility is detected, an error message will be prompted and the role execution will stop.
 
 ## How to?
 

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -12,6 +12,7 @@ avalanchego_db_dir: /var/lib/avalanchego/db
 avalanchego_conf_dir: /etc/avalanche/avalanchego/conf
 avalanchego_certs_dir: /etc/avalanche/avalanchego/staking
 avalanchego_log_dir: /var/log/avalanche/avalanchego
+avalanchego_vms_dir: /opt/avalanche/vms
 
 # User & network
 avalanchego_user: avalanche
@@ -36,11 +37,9 @@ avalanche_prefunded_username: ewoq
 avalanche_prefunded_password: I_l1ve_@_Endor
 avalanche_prefunded_private_key: PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN
 
-# Subnets whitelist & VMs aliases
+# Subnets whitelist
 avalanche_whitelisted_subnets: ""
-avalanche_vm_aliases:
-  tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH:
-    - timestampvm
-    - timestamp
-  spePNvBxaWSYL2tB5e2xMmMNBQkXMN8z2XEbz1ML2Aahatwoc:
-    - subnetevm
+
+# VMs
+avalanchego_vms_install:
+  - timestampvm=1.2.0

--- a/roles/node/handlers/main.yml
+++ b/roles/node/handlers/main.yml
@@ -5,3 +5,27 @@
   service:
     name: avalanchego
     state: restarted
+
+- name: Restart avalanchego
+  service:
+    name: avalanchego
+    state: restarted
+  listen: New VM
+# Cannot use admin.loadVMs yet as it does not detect version changes
+# See https://github.com/ava-labs/avalanchego/issues/1030
+# when: avalanchego_version is version('1.7.6', '<')
+
+# - name: Reload VMs
+#   uri:
+#     url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/admin"
+#     method: POST
+#     body_format: json
+#     body:
+#       jsonrpc: "2.0"
+#       method: admin.loadVMs
+#       params: {}
+#       id: 1
+#   register: load_vms_res
+#   failed_when: load_vms_res.json.error is defined
+#   listen: New VM
+#   when: avalanchego_version is version('1.7.6', '>=')

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -9,6 +9,8 @@
   file:
     path: "{{ item }}"
     state: directory
+    owner: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_user }}"
   loop:
     - "{{ avalanchego_install_dir }}/current/plugins"
     - "{{ avalanchego_install_dir }}/releases"
@@ -20,7 +22,7 @@
 - name: Download avalanchego binary
   get_url:
     url: "{{ avalanchego_binary_url }}"
-    dest: "{{ avalanchego_install_dir }}/releases/"
+    dest: "{{ avalanchego_install_dir }}/releases/{{ avalanchego_binary_name }}"
 
 - name: Unpack avalanchego binary
   unarchive:
@@ -29,18 +31,22 @@
     remote_src: yes
     creates: "{{ avalanchego_install_dir }}/avalanchego-v{{ avalanchego_version }}"
 
-- name: Create a symlink to current avalanchego binary
+- name: Create the symlink to current avalanchego binary
   file:
     src: "{{ avalanchego_install_dir }}/avalanchego-v{{ avalanchego_version }}/avalanchego"
     dest: "{{ avalanchego_install_dir }}/current/avalanchego"
     state: link
+    owner: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_user }}"
   notify: Restart avalanchego
 
-- name: Create a symlink to current evm binary
+- name: Create the symlink to current evm binary in plugins dir
   file:
     src: "{{ avalanchego_install_dir }}/avalanchego-v{{ avalanchego_version }}/plugins/evm"
     dest: "{{ avalanchego_install_dir }}/current/plugins/evm"
     state: link
+    owner: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_user }}"
   notify: Restart avalanchego
 
 - name: Upload nodes certificates
@@ -70,13 +76,24 @@
     dest: /etc/systemd/system/avalanchego.service
   notify: Restart avalanchego
 
-- name: Generate VMs aliases.json
-  copy:
-    dest: "{{ avalanchego_conf_dir }}/vms/aliases.json"
-    content: "{{ avalanche_vm_aliases | to_nice_json }}"
-  notify: Restart avalanchego
+- name: Install VMs
+  include_tasks: vm-install.yml
+  vars:
+    vm_name: "{{ vm.split('=')[0] }}"
+    vm_version: "{{ vm.split('=')[1] }}"
+    vm_info: "{{ avalanchego_vms_list[vm.split('=')[0]] }}"
+  loop: "{{ avalanchego_vms_install }}"
+  loop_control:
+    loop_var: vm
 
-- name: Make avalanche user owner of avalanche directories
+- name: Template aliases.json file
+  template:
+    src: aliases.json.j2
+    dest: "{{ avalanchego_conf_dir }}/vms/aliases.json"
+    lstrip_blocks: yes
+  notify: New VM
+
+- name: Make AvalancheGo user owner of avalanche directories
   file:
     path: "{{ item }}"
     state: directory
@@ -85,14 +102,16 @@
     group: "{{ avalanchego_user }}"
   loop:
     - "{{ avalanchego_install_dir }}"
-    - "{{ avalanchego_db_dir }}"
     - "{{ avalanchego_conf_dir }}"
     - "{{ avalanchego_certs_dir }}"
-    - "{{ avalanchego_log_dir }}"
+    - "{{ avalanchego_vms_dir }}"
 
 - name: Reload systemctl daemons
   systemd:
     daemon_reload: yes
+
+- name: Restart AvalancheGo and reload VMs if needed
+  meta: flush_handlers
 
 - name: Start and enable avalanchego.service
   service:

--- a/roles/node/tasks/vm-install.yml
+++ b/roles/node/tasks/vm-install.yml
@@ -1,0 +1,39 @@
+# Copyright (C) 2022, Gauthier Leonard
+# See the file LICENSE for licensing terms.
+---
+- name: Check that {{ vm_name }}={{ vm_version }} is compatible with avalanchego={{ avalanchego_version }}
+  debug:
+    msg: "AvalancheGo version {{ item.key }} {{ item.value }}: {{ avalanchego_version is version(item.value, item.key) }}"
+  run_once: yes
+  loop: "{{ vm_info.versions_comp[vm_version] | dict2items }}"
+  failed_when: not avalanchego_version is version(item.value, item.key)
+
+- name: Template {{ vm_name }} binary filename
+  set_fact:
+    vm_binary_name: "{{ vm_info.binary_prefix }}-v{{ vm_version }}.tar.gz"
+
+- name: Create {{ vm_name }} dir
+  file:
+    path: "{{ avalanchego_vms_dir }}/{{ vm_name }}/releases"
+    state: directory
+
+- name: Download {{ vm_name }} binary
+  get_url:
+    url: "{{ vm_info.download_url }}/v{{ vm_version }}/{{ vm_binary_name }}"
+    dest: "{{ avalanchego_vms_dir }}/{{ vm_name }}/releases/{{ vm_binary_name }}"
+
+- name: Unpack {{ vm_name }} binary
+  unarchive:
+    src: "{{ avalanchego_vms_dir }}/{{ vm_name }}/releases/{{ vm_binary_name }}"
+    dest: "{{ avalanchego_vms_dir }}/{{ vm_name }}"
+    remote_src: yes
+    creates: "{{ avalanchego_vms_dir }}/{{ vm_name}}/{{ vm_name }}-v{{ vm_version }}"
+
+- name: Create the symlink to {{ vm_name }} binary in plugins dir
+  file:
+    src: "{{ avalanchego_vms_dir }}/{{ vm_name }}/{{ vm_name }}-v{{ vm_version }}/{{ vm_name }}"
+    dest: "{{ avalanchego_install_dir }}/current/plugins/{{ vm_name }}"
+    state: link
+    owner: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_user }}"
+  notify: New VM

--- a/roles/node/templates/aliases.json.j2
+++ b/roles/node/templates/aliases.json.j2
@@ -1,0 +1,8 @@
+{# Copyright (C) 2022, Gauthier Leonard
+See the file LICENSE for licensing terms. #}
+{
+  {% for vm in avalanchego_vms_install %}
+  {% set vm_name = vm.split('=')[0] %}
+  "{{ avalanchego_vms_list[vm_name].id }}": {{ avalanchego_vms_list[vm_name].aliases | to_json }}{{ ',' if not loop.last else '' }}
+  {% endfor %}
+}

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -1,0 +1,51 @@
+---
+avalanchego_vms_list:
+  timestampvm:
+    id: tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH
+    aliases:
+      - timestampvm
+    download_url: https://github.com/Nuttymoon/timestampvm/releases/download
+    binary_prefix: timestampvm-linux-amd64
+    versions_comp:
+      1.2.0:
+        ge: 1.7.0
+        lt: 1.7.5
+      1.2.1:
+        ge: 1.7.4
+        lt: 1.7.5
+      1.2.2:
+        ge: 1.7.5
+        lt: 1.7.7
+
+  subnetevm:
+    id: spePNvBxaWSYL2tB5e2xMmMNBQkXMN8z2XEbz1ML2Aahatwoc
+    aliases:
+      - subnetevm
+    download_url: https://github.com/Nuttymoon/subnet-evm/releases/download
+    binary_prefix: subnetevm-linux-amd64
+    versions_comp:
+      0.1.0:
+        ge: 1.7.0
+        lt: 1.7.5
+      0.1.1:
+        ge: 1.7.5
+        lt: 1.7.7
+      0.1.2:
+        ge: 1.7.5
+        lt: 1.7.7
+      0.2.0:
+        ge: 1.7.7
+
+  spacesvm:
+    id: sqja3uK17MJxfC7AN8nGadBw9JK5BcrsNwNynsqP5Gih8M5Bm
+    aliases:
+      - spacesvm
+    download_url: https://github.com/Nuttymoon/spacesvm/releases/download
+    binary_prefix: spacesvm-linux-amd64
+    versions_comp:
+      0.0.1:
+        ge: 1.7.0
+        lt: 1.7.5
+      0.0.2:
+        ge: 1.7.5
+        lt: 1.7.7

--- a/roles/subnet/tasks/main.yml
+++ b/roles/subnet/tasks/main.yml
@@ -1,6 +1,22 @@
 # Copyright (C) 2022, Gauthier Leonard
 # See the file LICENSE for licensing terms.
 ---
+- name: Wait for P-Chain to be bootstrapped
+  uri:
+    url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/info"
+    method: POST
+    body_format: json
+    body:
+      jsonrpc: "2.0"
+      method: info.isBootstrapped
+      params:
+        chain: P
+      id: 1
+  register: bootstrapped_res
+  failed_when: bootstrapped_res.json.error is defined
+  until: bootstrapped_res.json.result.isBootstrapped
+  retries: 10
+
 - name: Check that subnet control user exists
   uri:
     url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/keystore"


### PR DESCRIPTION
Allow installing and upgrading VMs in `nuttymoon.avalanche.node` role. This is done by providing the list of VMs to install with `avalanchego_vms_install`.