### PR TITLE
feat: support node db bootstrapping

### DIFF
--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -5,6 +5,7 @@
 avalanchego_version: 1.7.3
 avalanchego_binary_name: "avalanchego-linux-amd64-v{{ avalanchego_version }}.tar.gz"
 avalanchego_binary_url: "https://github.com/ava-labs/avalanchego/releases/download/v{{ avalanchego_version }}/{{ avalanchego_binary_name }}"
+avalanchego_bootstrap_db: ""
 
 # Install directories
 avalanchego_install_dir: /opt/avalanche/avalanchego

--- a/roles/node/tasks/bootstrap-db.yml
+++ b/roles/node/tasks/bootstrap-db.yml
@@ -1,0 +1,9 @@
+# Copyright (C) 2022, Gauthier Leonard
+# See the file LICENSE for licensing terms.
+---
+
+- name: Unpack bootstrap database
+  unarchive:
+    src: "{{ avalanchego_bootstrap_db }}"
+    dest: "{{ avalanchego_db_dir }}"
+    creates: "{{ avalanchego_db_dir }}/{{ avalanchego_network_id }}"

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -19,6 +19,10 @@
     - "{{ avalanchego_certs_dir }}"
     - "{{ avalanchego_log_dir }}"
 
+- name: Bootstrap database
+  include_tasks: bootstrap-db.yml
+  when: (avalanchego_bootstrap_db is defined) and (avalanchego_bootstrap_db|length > 0)
+
 - name: Download avalanchego binary
   get_url:
     url: "{{ avalanchego_binary_url }}"


### PR DESCRIPTION
Fix #6 

Example `group_vars` configuration:

```
# Network bootstrap
avalanchego_bootstrap_db: "{{ inventory_dir }}/../../files/03-25-2022-testnet-db.tar.gz "
```

With [03-25-2022-testnet-db.tar.gz](fuji-dbs.s3.amazonaws.com/03-25-2022-testnet-db.tar.gz )