### PR TITLE
VMs versions update

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ namespace: nuttymoon
 name: avalanche
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.1.5
+version: 0.1.6
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/node/README.md
+++ b/roles/node/README.md
@@ -70,18 +70,21 @@ To install a VM on the node, add it to `avalanchego_vms_install` following `VM_N
 
 List of VMs currently available for install:
 
-- `timestampvm`: The [Timestamp Virtual Machine](https://github.com/ava-labs/timestampvm) in versions `1.2.0` and later
-- `subnetevm`: The [Subnet EVM](https://github.com/ava-labs/subnet-evm) in all versions
+- `blobvm`: The [Blob Virtual Machine](https://github.com/ava-labs/blobvm) in all versions
 - `spacesvm`: The [Spaces Virtual Machine](https://github.com/ava-labs/spacesvm) in all versions
+- `subnetevm`: The [Subnet EVM](https://github.com/ava-labs/subnet-evm) in all versions
+- `timestampvm`: The [Timestamp Virtual Machine](https://github.com/ava-labs/timestampvm) in versions `1.2.0` and later
 
 Here is the compatibility matrix with AvalancheGo versions:
 
-| AvalancheGo     | `timestampvm` | `subnetevm` | `spacesvm` |
-| --------------- | ------------- | ----------- | ---------- |
-| `1.7.[0,1,2,3]` | `1.2.0`       | `0.1.0`     | `0.0.1`    |
-| `1.7.4`         | `1.2.[0,1]`   | `0.1.0`     | `0.0.1`    |
-| `1.7.[5,6]`     | `1.2.2`       | `0.1.[1,2]` | `0.0.2`    |
-| `1.7.7`         | -             | `0.2.0`     | -          |
+| AvalancheGo     | `blobvm`      | `spacesvm` | `subnetevm`   | `timestampvm` |
+| --------------- | ------------- | ---------- | ------------- | ------------- |
+| `1.7.0-1.7.4`   | -             | `0.0.1`    | `0.1.0`       | `1.2.0`       |
+| `1.7.5-1.7.6`   | -             | `0.0.2`    | `0.1.1-0.1.2` | `1.2.2`       |
+| `1.7.7-1.7.9`   | `0.0.1-0.0.2` | `0.0.3`    | `0.2.0`       | `1.2.3`       |
+| `1.7.10`        | `0.0.3`       | `0.0.4`    | `0.2.1`       | `1.2.4`       |
+| `1.7.11-1.7.12` | `0.0.4`       | `0.0.5`    | `0.2.2`       | `1.2.5`       |
+| `1.7.13-1.7.14` | `0.0.5-0.0.6` | `0.0.6`    | `0.2.3-0.2.5` | -             |
 
 **Note:** If an versions incompatibility is detected, an error message will be prompted and the role execution will stop.
 

--- a/roles/node/tasks/install-vm.yml
+++ b/roles/node/tasks/install-vm.yml
@@ -23,6 +23,7 @@
   get_url:
     url: "{{ vm_info.download_url }}/v{{ vm_version }}/{{ vm_binary_name }}"
     dest: "{{ avalanchego_vms_dir }}/{{ vm_name }}/releases/{{ vm_binary_name }}"
+    checksum: "sha512:{{ vm_info.download_url }}/v{{ vm_version }}/{{ vm_binary_name }}.sha512"
     owner: "{{ avalanchego_user }}"
     group: "{{ avalanchego_user }}"
 

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -2,6 +2,31 @@
 # See the file LICENSE for licensing terms.
 ---
 avalanchego_vms_list:
+  blobvm:
+    aliases:
+    - blobvm
+    binary_prefix: blobvm-linux-amd64
+    download_url: https://github.com/Nuttymoon/blobvm/releases/download
+    id: kM6h4LYe3AcEU1MB2UNg6ubzAiDAALZzpVrbX8zn3hXF6Avd8
+    versions_comp:
+      0.0.1:
+        ge: 1.7.7
+        le: 1.7.9
+      0.0.2:
+        ge: 1.7.7
+        le: 1.7.9
+      0.0.3:
+        ge: 1.7.10
+        le: 1.7.10
+      0.0.4:
+        ge: 1.7.11
+        le: 1.7.12
+      0.0.5:
+        ge: 1.7.13
+        le: 1.7.14
+      0.0.6:
+        ge: 1.7.13
+        le: 1.7.14
   spacesvm:
     aliases:
     - spacesvm
@@ -57,10 +82,13 @@ avalanchego_vms_list:
         le: 1.7.12
       0.2.3:
         ge: 1.7.13
-        le: 1.7.13
+        le: 1.7.14
       0.2.4:
         ge: 1.7.13
-        le: 1.7.13
+        le: 1.7.14
+      0.2.5:
+        ge: 1.7.13
+        le: 1.7.14
   timestampvm:
     aliases:
     - timestampvm

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -2,35 +2,40 @@
 # See the file LICENSE for licensing terms.
 ---
 avalanchego_vms_list:
-  timestampvm:
-    id: tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH
+  spacesvm:
     aliases:
-      - timestampvm
-    download_url: https://github.com/Nuttymoon/timestampvm/releases/download
-    binary_prefix: timestampvm-linux-amd64
+    - spacesvm
+    binary_prefix: spacesvm-linux-amd64
+    download_url: https://github.com/Nuttymoon/spacesvm/releases/download
+    id: sqja3uK17MJxfC7AN8nGadBw9JK5BcrsNwNynsqP5Gih8M5Bm
     versions_comp:
-      1.2.0:
+      0.0.1:
         ge: 1.7.0
         le: 1.7.4
-      1.2.1:
-        ge: 1.7.4
-        le: 1.7.4
-      1.2.2:
+      0.0.2:
         ge: 1.7.5
         le: 1.7.6
-      1.2.3:
+      0.0.3:
         ge: 1.7.7
-        le: 1.7.7
-    genesis_rpc_extra_path: ""
-    genesis_build_method: timestampvm.encode
-    genesis_json_key: bytes
-
+        le: 1.7.9
+      0.0.4:
+        ge: 1.7.10
+        le: 1.7.10
+      0.0.5:
+        ge: 1.7.11
+        le: 1.7.12
+      0.0.6:
+        ge: 1.7.13
+        le: 1.7.13
   subnetevm:
-    id: spePNvBxaWSYL2tB5e2xMmMNBQkXMN8z2XEbz1ML2Aahatwoc
     aliases:
-      - subnetevm
-    download_url: https://github.com/Nuttymoon/subnet-evm/releases/download
+    - subnetevm
     binary_prefix: subnetevm-linux-amd64
+    download_url: https://github.com/Nuttymoon/subnet-evm/releases/download
+    genesis_build_method: subnetevm.buildGenesis
+    genesis_json_key: genesisBytes
+    genesis_rpc_extra_path: /rpc
+    id: spePNvBxaWSYL2tB5e2xMmMNBQkXMN8z2XEbz1ML2Aahatwoc
     versions_comp:
       0.1.0:
         ge: 1.7.0
@@ -47,26 +52,40 @@ avalanchego_vms_list:
       0.2.1:
         ge: 1.7.10
         le: 1.7.10
-    genesis_rpc_extra_path: "/rpc"
-    genesis_build_method: subnetevm.buildGenesis
-    genesis_json_key: genesisBytes
-
-  spacesvm:
-    id: sqja3uK17MJxfC7AN8nGadBw9JK5BcrsNwNynsqP5Gih8M5Bm
+      0.2.2:
+        ge: 1.7.11
+        le: 1.7.12
+      0.2.3:
+        ge: 1.7.13
+        le: 1.7.13
+      0.2.4:
+        ge: 1.7.13
+        le: 1.7.13
+  timestampvm:
     aliases:
-      - spacesvm
-    download_url: https://github.com/Nuttymoon/spacesvm/releases/download
-    binary_prefix: spacesvm-linux-amd64
+    - timestampvm
+    binary_prefix: timestampvm-linux-amd64
+    download_url: https://github.com/Nuttymoon/timestampvm/releases/download
+    genesis_build_method: timestampvm.encode
+    genesis_json_key: bytes
+    genesis_rpc_extra_path: ''
+    id: tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH
     versions_comp:
-      0.0.1:
+      1.2.0:
         ge: 1.7.0
         le: 1.7.4
-      0.0.2:
+      1.2.1:
+        ge: 1.7.0
+        le: 1.7.4
+      1.2.2:
         ge: 1.7.5
         le: 1.7.6
-      0.0.3:
+      1.2.3:
         ge: 1.7.7
         le: 1.7.9
-      0.0.4:
+      1.2.4:
         ge: 1.7.10
         le: 1.7.10
+      1.2.5:
+        ge: 1.7.11
+        le: 1.7.12

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+packaging>=20.3
+PyYAML>=5.3
+requests>=2.22

--- a/scripts/update_vm_versions.py
+++ b/scripts/update_vm_versions.py
@@ -15,6 +15,7 @@ GITHUB_API_URL = 'https://api.github.com'
 VARS_YAML_PATH = '../roles/node/vars/main.yml'
 VARS_YAML_HEADER_SIZE = 3
 VMS_REPOS = {
+    'blobvm': 'Nuttymoon/blobvm',
     'spacesvm': 'Nuttymoon/spacesvm',
     'subnetevm': 'Nuttymoon/subnet-evm',
     # Versions not available in timestampvm's README

--- a/scripts/update_vm_versions.py
+++ b/scripts/update_vm_versions.py
@@ -1,0 +1,77 @@
+#!/bin/python3
+
+import os
+import requests
+import re
+import yaml
+from packaging import version
+
+# Update the avalanchego_vms_list variable in roles/node/vars
+# with new VM versions available and their compatibility with AvalancheGo
+
+GITHUB_RAW_URL = 'https://raw.githubusercontent.com'
+GITHUB_API_URL = 'https://api.github.com'
+
+VARS_YAML_PATH = '../roles/node/vars/main.yml'
+VARS_YAML_HEADER_SIZE = 3
+VMS_REPOS = {
+    'spacesvm': 'Nuttymoon/spacesvm',
+    'subnetevm': 'Nuttymoon/subnet-evm',
+    # Versions not available in timestampvm's README
+    # 'timestampvm': 'Nuttymoon/timestampvm',
+}
+
+vms_versions_comp = {}
+
+# For each VM, fetch AvalancheGo compatibility info from README
+for vm, repo in VMS_REPOS.items():
+    repo_info = requests.get(f'{GITHUB_API_URL}/repos/{repo}')
+    default_branch = repo_info.json()['default_branch']
+
+    readme_url = f'{GITHUB_RAW_URL}/{repo}/{default_branch}/README.md'
+    readme_raw = requests.get(readme_url)
+
+    compatibility_specs = list(
+        re.finditer(
+            r'^\[v(?P<vm_start_ver>\d+\.\d+\.\d+)-?v?(?P<vm_end_ver>\d+\.\d+\.\d+)?\] '
+            r'AvalancheGo@v(?P<avax_start_ver>\d+\.\d+\.\d+)-?v?(?P<avax_end_ver>\d+\.\d+\.\d+)?$',
+            readme_raw.text,
+            flags=re.MULTILINE,
+        )
+    )
+
+    # Iterate on all versions
+    versions_comp = {}
+    for c in compatibility_specs:
+        vm_start_ver = version.parse(c.group('vm_start_ver'))
+        vm_end_ver = version.parse(c.group('vm_end_ver') or c.group('vm_start_ver'))
+
+        for major in range(vm_start_ver.major, vm_end_ver.major + 1):
+            for minor in range(vm_start_ver.minor, vm_end_ver.minor + 1):
+                for micro in range(vm_start_ver.micro, vm_end_ver.micro + 1):
+                    versions_comp.update(
+                        {
+                            f'{major}.{minor}.{micro}': {
+                                'ge': c.group('avax_start_ver'),
+                                'le': c.group('avax_end_ver')
+                                or c.group('avax_start_ver'),
+                            }
+                        }
+                    )
+
+    vms_versions_comp.update({vm: versions_comp})
+
+vars_yaml_abs_path = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)), VARS_YAML_PATH
+)
+
+with open(vars_yaml_abs_path) as vars_yaml:
+    vars_header = ''.join([vars_yaml.readline() for l in range(VARS_YAML_HEADER_SIZE)])
+    vars_obj = yaml.load(vars_yaml, Loader=yaml.CLoader)
+
+# Enrich the avalanchego_vms_list with updated versions_comp
+for vm, v_comp in vms_versions_comp.items():
+    vars_obj['avalanchego_vms_list'][vm]['versions_comp'] = v_comp
+
+with open(vars_yaml_abs_path, 'w') as vars_yaml:
+    vars_yaml.write(vars_header + yaml.dump(vars_obj, Dumper=yaml.CDumper))


### PR DESCRIPTION
This PR adds the script `update_vm_versions.py` that allows to easily update `avalanchego_vms_list` in `roles/node/vars/main.yml` with the new VMs releases and their compatibility with AvalancheGo.

It also adds a checksum check upon VM binary download.